### PR TITLE
Allow services class declaration to be overridden

### DIFF
--- a/App/Resources/config/services.xml
+++ b/App/Resources/config/services.xml
@@ -4,24 +4,32 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="spec_gen.state_workflow.service.class">SpecGen\StateWorkflowSpecGenBundle\App\SpecificationService</parameter>
+        <parameter key="spec_gen.state_workflow.workflow.generate_workflow_specifications.cli.class">SpecGen\StateWorkflowSpecGenBundle\UI\Cli\GenerateWorkflowSpecificationsCommand</parameter>
+        <parameter key="spec_gen.state_workflow.cytoscape_specification_representation.generator.class">SpecGen\StateWorkflowSpecGenBundle\Infra\CytoscapeSpecificationRepresentationGenerator</parameter>
+        <parameter key="spec_gen.state_workflow.file_system.writer.class">SpecGen\StateWorkflowSpecGenBundle\Infra\FileSystemSpecificationWriter</parameter>
+        <parameter key="spec_gen.state_workflow.workflow.container.class">SpecGen\StateWorkflowSpecGenBundle\Domain\WorkflowContainer</parameter>
+    </parameters>
+
     <services>
         <!-- Bounded Context entry point -->
-        <service id="spec_gen.state_workflow.service" class="SpecGen\StateWorkflowSpecGenBundle\App\SpecificationService" public="true">
+        <service id="spec_gen.state_workflow.service" class="%spec_gen.state_workflow.service.class%" public="true">
             <argument type="service" id="spec_gen.state_workflow.workflow.container" />
             <argument type="service" id="spec_gen.state_workflow.cytoscape_specification_representation.generator" />
             <argument type="service" id="spec_gen.state_workflow.file_system.writer" />
         </service>
 
         <!-- CLI -->
-        <service id="spec_gen.state_workflow.workflow.generate_workflow_specifications.cli" class="SpecGen\StateWorkflowSpecGenBundle\UI\Cli\GenerateWorkflowSpecificationsCommand" public="true">
+        <service id="spec_gen.state_workflow.workflow.generate_workflow_specifications.cli" class="%spec_gen.state_workflow.workflow.generate_workflow_specifications.cli.class%" public="true">
             <argument type="service" id="spec_gen.state_workflow.service" />
             <tag name="console.command" />
         </service>
 
-        <service id="spec_gen.state_workflow.cytoscape_specification_representation.generator" class="SpecGen\StateWorkflowSpecGenBundle\Infra\CytoscapeSpecificationRepresentationGenerator" public="false"/>
-        <service id="spec_gen.state_workflow.file_system.writer" class="SpecGen\StateWorkflowSpecGenBundle\Infra\FileSystemSpecificationWriter" public="false"/>
+        <service id="spec_gen.state_workflow.cytoscape_specification_representation.generator" class="%spec_gen.state_workflow.cytoscape_specification_representation.generator.class%" public="false"/>
+        <service id="spec_gen.state_workflow.file_system.writer" class="%spec_gen.state_workflow.file_system.writer.class%" public="false"/>
 
-        <service id="spec_gen.state_workflow.workflow.container" class="SpecGen\StateWorkflowSpecGenBundle\Domain\WorkflowContainer" public="false">
+        <service id="spec_gen.state_workflow.workflow.container" class="%spec_gen.state_workflow.workflow.container.class%" public="false">
         </service>
     </services>
 </container>


### PR DESCRIPTION
Now you can inject whatever Spec Writer/Generator
 you need

@see http://symfony.com/doc/current/cookbook/bundles/override.html#services-configuration
